### PR TITLE
[FE] feat: setting react-router-dom

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-router-dom:
+    specifier: ^6.22.0
+    version: 6.22.0(react-dom@18.2.0)(react@18.2.0)
 
 devDependencies:
   '@types/react':
@@ -519,6 +522,11 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
     dev: true
+
+  /@remix-run/router@1.15.0:
+    resolution: {integrity: sha512-HOil5aFtme37dVQTB6M34G95kPM3MMuqSmIRVCC52eKV+Y/tGSqw9P3rWhlAx6A+mz+MoX+XxsGsNJbaI5qCgQ==}
+    engines: {node: '>=14.0.0'}
+    dev: false
 
   /@rollup/rollup-android-arm-eabi@4.9.6:
     resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
@@ -2395,6 +2403,29 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  /react-router-dom@6.22.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-z2w+M4tH5wlcLmH3BMMOMdrtrJ9T3oJJNsAlBJbwk+8Syxd5WFJ7J5dxMEW0/GEXD1BBis4uXRrNIz3mORr0ag==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.15.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-router: 6.22.0(react@18.2.0)
+    dev: false
+
+  /react-router@6.22.0(react@18.2.0):
+    resolution: {integrity: sha512-q2yemJeg6gw/YixRlRnVx6IRJWZD6fonnfZhN1JIOhV2iJCPeRNSH3V1ISwHf+JWcESzLC3BOLD1T07tmO5dmg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.15.0
+      react: 18.2.0
+    dev: false
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,31 +1,77 @@
 import './App.css'
 
-import {useState} from 'react'
-
-import viteLogo from '../public/vite.svg'
-import reactLogo from './assets/react.svg'
+import {ReactNode} from 'react'
+import {
+  createBrowserRouter,
+  createRoutesFromElements,
+  redirect,
+  Route,
+  RouterProvider,
+  useRouteLoaderData,
+} from 'react-router-dom'
 
 export function App() {
-  const [count, setCount] = useState(0)
+  return <RouterProvider router={router} fallbackElement={<p>Initial Load...</p>} />
+}
 
-  return (
+const router = createBrowserRouter(
+  createRoutesFromElements(
     <>
-      <div>
-        <a href="https://vitejs.dev" target="_blank" rel="noreferrer">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank" rel="noreferrer">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
-    </>
-  )
+      <Route index path="/" element={<>landing page</>} />
+      <Route
+        id="root"
+        loader={({request}) => {
+          // TODO: neet to authorize
+          const isAuth = false
+
+          if (!isAuth) {
+            return redirect('/login')
+          }
+          return {isStudent: true}
+        }}
+        element={<>home/layout</>}
+      >
+        <Route
+          path="/dashboard"
+          element={
+            <RequireAuth>
+              {({isStudent}) => {
+                return isStudent ? <>dashboard/student</> : <>dashboard/instructor</>
+              }}
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/history"
+          element={
+            <RequireAuth>
+              {({isStudent}) => {
+                return isStudent ? <>history/student</> : <>history/instructor</>
+              }}
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/schedule"
+          element={
+            <RequireAuth>
+              {({isStudent}) => {
+                return isStudent ? <>schedule/student</> : <>schedule/instructor</>
+              }}
+            </RequireAuth>
+          }
+        />
+      </Route>
+    </>,
+  ),
+)
+
+interface RequireAuthProps {
+  children: ReactNode | ((arg: any) => ReactNode)
+}
+
+function RequireAuth({children}: RequireAuthProps) {
+  const user = useRouteLoaderData('root')
+
+  return <>{typeof children === 'function' ? children(user) : children}</>
 }


### PR DESCRIPTION
## 구현 내용

- close #16 
- react-router-dom 세팅

## 고민 사항

- 인가 처리에 대한 고민
  - react router dom 의 `loader` 기능을 이용해서 route 가 될 때마다 authorization 하도록 구현
  - `RequireAuth` component 를 통해 하위 route(/dashboard, /history 등)에서 `useRouteLoaderData` 를 통해 사용자 정보를 받아서 route 분기처리 함

## 기타
- [`react-router-dom` official auth router prodvider example](https://github.com/remix-run/react-router/tree/dev/examples/auth-router-provider)
