### PR TITLE
[FE] feat: button component

### DIFF
--- a/frontend/src/components/button/README.md
+++ b/frontend/src/components/button/README.md
@@ -1,0 +1,22 @@
+# Button
+
+## description
+
+- 기본 버튼 컴포넌트
+
+## props
+
+|   name    |       description       |  default  |
+| :-------: | :---------------------: | :-------: |
+|  `color`  |       text color        | 'gray50'  |
+| `bgColor` | button background color | 'primary' |
+
+## use case
+
+```tsx
+<Button>I'm here<Button>
+
+<Button color='black' bgColor='warning'>I'm here<Button>
+
+<Button disabled>I'm here<Button>
+```

--- a/frontend/src/components/button/button.tsx
+++ b/frontend/src/components/button/button.tsx
@@ -1,0 +1,51 @@
+import type {Theme} from '@emotion/react'
+import styled from '@emotion/styled'
+import {ButtonHTMLAttributes, PropsWithChildren} from 'react'
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * text color
+   * @default 'gray50'
+   */
+  color?: keyof Theme['color']
+  /**
+   * button background color
+   * @default 'primary'
+   */
+  bgColor?: keyof Theme['color']
+}
+
+export function ButtonBase({
+  children,
+  color = 'gray50',
+  bgColor = 'primary',
+  ...props
+}: PropsWithChildren<Props>) {
+  return (
+    <Button {...props} color={color} bgColor={bgColor}>
+      {children}
+    </Button>
+  )
+}
+
+const Button = styled.button<{color: keyof Theme['color']; bgColor: keyof Theme['color']}>`
+  background-color: ${({theme, bgColor}) => theme.color[bgColor]};
+  color: ${({theme, color}) => theme.color[color]};
+  padding: 0.8rem;
+  font-size: 1.4rem;
+  font-weight: 700;
+  line-height: 1.7rem;
+  text-align: center;
+  border-radius: 0.8rem;
+  cursor: pointer;
+  width: 100%;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+`

--- a/frontend/src/components/button/index.ts
+++ b/frontend/src/components/button/index.ts
@@ -1,0 +1,1 @@
+export {ButtonBase as Button} from './button'


### PR DESCRIPTION
## 구현 내용

- close #23 
- `Button` 컴포넌트 작성
  - `Button` 컴포넌트에 icon 기능은 아직 하지 않음.

## 고민 사항

- `color`, `bgColor` props 타입추론이 될 수 있도록 타입을 지정해줌. 컴포넌트를 사용하는 개발자 경험을 위함
```ts
interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
  color?: keyof Theme['color']
  bgColor?: keyof Theme['color']
}
```

## 기타
