### PR TITLE
[FE] feat: divider component

### DIFF
--- a/frontend/src/components/divider/README.md
+++ b/frontend/src/components/divider/README.md
@@ -1,0 +1,24 @@
+## description
+
+- 요소 간 분리를 위한 divider 컴포넌트
+
+## props
+
+|    name     |                                             description                                             |   default    |
+| :---------: | :-------------------------------------------------------------------------------------------------: | :----------: |
+|   rounded   |                                        whether or not round                                         |    false     |
+| orientation |                                        divider's orientation                                        | `horizontal` |
+|    color    |                                           divider's color                                           |  `gray300`   |
+|  flexItem   | if being used in a container styled as `display: flex`, a vertical divider will have correct height |    false     |
+
+## use case
+
+```tsx
+<Divider />
+
+<Divider rounded />
+
+<div style={{display: 'flex'}}>
+    <Divider orientation='vertical' flexItem />
+</div>
+```

--- a/frontend/src/components/divider/divider.tsx
+++ b/frontend/src/components/divider/divider.tsx
@@ -1,0 +1,45 @@
+import {Theme, useTheme} from '@emotion/react'
+import styled from '@emotion/styled'
+import {HTMLAttributes} from 'react'
+
+interface Props extends HTMLAttributes<HTMLHRElement> {
+  rounded?: boolean
+  color?: keyof Theme['color']
+  orientation?: 'vertical' | 'horizontal'
+  flexItem?: boolean
+}
+
+export function Divider({
+  rounded = false,
+  color = 'gray300',
+  orientation = 'horizontal',
+  flexItem = false,
+  ...props
+}: Props) {
+  const theme = useTheme()
+  return (
+    <Hr
+      rounded={rounded}
+      color={theme.color[color]}
+      orientation={orientation}
+      flexItem={flexItem}
+      {...props}
+    />
+  )
+}
+
+interface HrProps {
+  rounded?: boolean
+  orientation?: 'vertical' | 'horizontal'
+  flexItem?: boolean
+}
+
+const Hr = styled.hr<HrProps>`
+  text-align: center;
+  flex-shrink: 0;
+  align-self: stretch;
+  width: ${({orientation}) => (orientation === 'horizontal' ? '100%' : '0.1rem')};
+  height: ${({orientation, flexItem}) =>
+    orientation === 'horizontal' ? '0.1rem' : flexItem ? 'auto' : '100%'};
+  border-radius: ${({rounded}) => rounded && '9999px'};
+`

--- a/frontend/src/components/divider/divider.tsx
+++ b/frontend/src/components/divider/divider.tsx
@@ -2,11 +2,8 @@ import {Theme, useTheme} from '@emotion/react'
 import styled from '@emotion/styled'
 import {HTMLAttributes} from 'react'
 
-interface Props extends HTMLAttributes<HTMLHRElement> {
-  rounded?: boolean
+interface Props extends HTMLAttributes<HTMLHRElement>, HrProps {
   color?: keyof Theme['color']
-  orientation?: 'vertical' | 'horizontal'
-  flexItem?: boolean
 }
 
 export function Divider({
@@ -41,5 +38,5 @@ const Hr = styled.hr<HrProps>`
   width: ${({orientation}) => (orientation === 'horizontal' ? '100%' : '0.1rem')};
   height: ${({orientation, flexItem}) =>
     orientation === 'horizontal' ? '0.1rem' : flexItem ? 'auto' : '100%'};
-  border-radius: ${({rounded}) => rounded && '9999px'};
+  border-radius: ${({rounded}) => rounded && '50%'};
 `

--- a/frontend/src/components/divider/index.ts
+++ b/frontend/src/components/divider/index.ts
@@ -1,0 +1,1 @@
+export {Divider} from './divider'


### PR DESCRIPTION
## 구현 내용

- close #45 

## 고민 사항

- 아래 use case 에 따라 props 설계
  - 수직 or 수평 divider
  - divider의 끝이 둥글 수 있음
  - flex container 내에서 사용
  - 색상 변경 가능

## 기타
- [Material UI `Divider` component](https://mui.com/material-ui/react-divider/)
