### PR TITLE
[BE] feat : 특정 강사 상세 정보 출력 API 개발

### DIFF
--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/InstructorController.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/InstructorController.java
@@ -1,14 +1,10 @@
 package com.drivingtoday.domain.instructor;
 
 import com.drivingtoday.domain.instructor.dto.InstructorDetailResponse;
-import com.drivingtoday.domain.review.Review;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,11 +13,8 @@ public class InstructorController {
 
     @GetMapping("/instructors/{instructor_id}")
     @Operation(summary = "강사 상세 정보 반환하는 API")
-    public ResponseEntity<InstructorDetailResponse> instructorDetails(@PathVariable("instructor_id") Long instructorId,
-                                                                      @RequestParam("pageNumber") Integer pageNumber,
-                                                                      @RequestParam("pageSize") Integer pageSize) {
-        InstructorDetailResponse response =
-                instructorFindService.findInstructor(instructorId, pageNumber, pageSize);
+    public ResponseEntity<InstructorDetailResponse> instructorDetails(@PathVariable("instructor_id") Long instructorId) {
+        InstructorDetailResponse response = instructorFindService.findInstructor(instructorId);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/InstructorController.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/InstructorController.java
@@ -1,0 +1,28 @@
+package com.drivingtoday.domain.instructor;
+
+import com.drivingtoday.domain.instructor.dto.InstructorDetailResponse;
+import com.drivingtoday.domain.review.Review;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class InstructorController {
+    private final InstructorFindService instructorFindService;
+
+    @GetMapping("/instructors/{instructor_id}")
+    @Operation(summary = "강사 상세 정보 반환하는 API")
+    public ResponseEntity<InstructorDetailResponse> instructorDetails(@PathVariable("instructor_id") Long instructorId,
+                                                                      @RequestParam("pageNumber") Integer pageNumber,
+                                                                      @RequestParam("pageSize") Integer pageSize) {
+        InstructorDetailResponse response =
+                instructorFindService.findInstructor(instructorId, pageNumber, pageSize);
+        return ResponseEntity.ok(response);
+    }
+}
+

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/InstructorFindService.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/InstructorFindService.java
@@ -1,0 +1,34 @@
+package com.drivingtoday.domain.instructor;
+
+import com.drivingtoday.domain.instructor.dto.InstructorDetailResponse;
+import com.drivingtoday.domain.review.Review;
+import com.drivingtoday.domain.review.ReviewRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InstructorFindService {
+
+    private final InstructorRepository instructorRepository;
+    private final ReviewRepository reviewRepository;
+
+    @Transactional
+    public InstructorDetailResponse findInstructor(Long instructorId, Integer pageNumber, Integer pageSize) {
+        Instructor instructor = instructorRepository.findById(instructorId)
+                .orElseThrow(() -> new RuntimeException("해당 강사가 존재하지 않습니다."));
+
+        // 페이지 번호 1부터 시작, 최근 생성 순으로 정렬
+        List<Review> reviews = reviewRepository.findAllByInstructorId(instructorId,
+                        PageRequest.of(pageNumber - 1, pageSize,
+                                Sort.by("createdAt").descending())).getContent();
+
+        return InstructorDetailResponse.of(instructor, reviews);
+    }
+}
+

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/InstructorFindService.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/InstructorFindService.java
@@ -1,34 +1,21 @@
 package com.drivingtoday.domain.instructor;
 
 import com.drivingtoday.domain.instructor.dto.InstructorDetailResponse;
-import com.drivingtoday.domain.review.Review;
-import com.drivingtoday.domain.review.ReviewRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class InstructorFindService {
 
     private final InstructorRepository instructorRepository;
-    private final ReviewRepository reviewRepository;
 
     @Transactional
-    public InstructorDetailResponse findInstructor(Long instructorId, Integer pageNumber, Integer pageSize) {
+    public InstructorDetailResponse findInstructor(Long instructorId) {
         Instructor instructor = instructorRepository.findById(instructorId)
                 .orElseThrow(() -> new RuntimeException("해당 강사가 존재하지 않습니다."));
-
-        // 페이지 번호 1부터 시작, 최근 생성 순으로 정렬
-        List<Review> reviews = reviewRepository.findAllByInstructorId(instructorId,
-                        PageRequest.of(pageNumber - 1, pageSize,
-                                Sort.by("createdAt").descending())).getContent();
-
-        return InstructorDetailResponse.of(instructor, reviews);
+        return InstructorDetailResponse.from(instructor);
     }
 }
 

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/AcademyInfo.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/AcademyInfo.java
@@ -1,0 +1,23 @@
+package com.drivingtoday.domain.instructor.dto;
+
+import com.drivingtoday.domain.academy.Academy;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AcademyInfo {
+    private String name;
+    private Double latitude;
+    private Double longitude;
+    private Boolean cert;
+
+    public static AcademyInfo from(Academy academy) {
+        return AcademyInfo.builder()
+                .name(academy.getName())
+                .latitude(academy.getLatitude())
+                .longitude(academy.getLongitude())
+                .cert(academy.getCert())
+                .build();
+    }
+}

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/InstructorDetailResponse.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/InstructorDetailResponse.java
@@ -12,13 +12,11 @@ import java.util.List;
 public class InstructorDetailResponse {
     private InstructorInfo instructorInfo;
     private AcademyInfo academyInfo;
-    private List<ReviewDetail> reviews;
 
-    public static InstructorDetailResponse of(Instructor instructor, List<Review> reviews) {
+    public static InstructorDetailResponse from(Instructor instructor) {
         return InstructorDetailResponse.builder()
                 .instructorInfo(InstructorInfo.from(instructor))
                 .academyInfo(AcademyInfo.from(instructor.getAcademy()))
-                .reviews(reviews.stream().map(ReviewDetail::from).toList())
                 .build();
     }
 }

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/InstructorDetailResponse.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/InstructorDetailResponse.java
@@ -1,0 +1,26 @@
+package com.drivingtoday.domain.instructor.dto;
+
+import com.drivingtoday.domain.instructor.Instructor;
+import com.drivingtoday.domain.review.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class InstructorDetailResponse {
+    private InstructorInfo instructorInfo;
+    private AcademyInfo academyInfo;
+    private List<ReviewDetail> reviews;
+
+    public static InstructorDetailResponse of(Instructor instructor, List<Review> reviews) {
+        return InstructorDetailResponse.builder()
+                .instructorInfo(InstructorInfo.from(instructor))
+                .academyInfo(AcademyInfo.from(instructor.getAcademy()))
+                .reviews(reviews.stream().map(ReviewDetail::from).toList())
+                .build();
+    }
+}
+
+

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/InstructorInfo.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/InstructorInfo.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class InstructorInfo {
+    private Long id;
     private String name;
     private String phoneNumber;
     private String instructorImage;
@@ -15,6 +16,7 @@ public class InstructorInfo {
 
     public static InstructorInfo from(Instructor instructor) {
         return InstructorInfo.builder()
+                .id(instructor.getId())
                 .name(instructor.getName())
                 .phoneNumber(instructor.getPhoneNumber())
                 .instructorImage(instructor.getInstructorImage())

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/InstructorInfo.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/InstructorInfo.java
@@ -1,0 +1,25 @@
+package com.drivingtoday.domain.instructor.dto;
+
+import com.drivingtoday.domain.instructor.Instructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class InstructorInfo {
+    private String name;
+    private String phoneNumber;
+    private String instructorImage;
+    private Integer pricePerHour;
+    private String introduction;
+
+    public static InstructorInfo from(Instructor instructor) {
+        return InstructorInfo.builder()
+                .name(instructor.getName())
+                .phoneNumber(instructor.getPhoneNumber())
+                .instructorImage(instructor.getInstructorImage())
+                .pricePerHour(instructor.getPricePerHour())
+                .introduction(instructor.getIntroduction())
+                .build();
+    }
+}

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/ReviewDetail.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/ReviewDetail.java
@@ -1,0 +1,23 @@
+package com.drivingtoday.domain.instructor.dto;
+
+import com.drivingtoday.domain.review.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReviewDetail {
+    private String contents;
+    private Double rating;
+    private LocalDateTime createdAt;
+
+    public static ReviewDetail from(Review review) {
+        return ReviewDetail.builder()
+                .contents(review.getContents())
+                .rating(review.getRating())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/ReviewDetail.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/instructor/dto/ReviewDetail.java
@@ -9,12 +9,14 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class ReviewDetail {
+    private String reviewerName;
     private String contents;
     private Double rating;
     private LocalDateTime createdAt;
 
     public static ReviewDetail from(Review review) {
         return ReviewDetail.builder()
+                .reviewerName(review.getStudent().getName())
                 .contents(review.getContents())
                 .rating(review.getRating())
                 .createdAt(review.getCreatedAt())

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/review/Review.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/review/Review.java
@@ -26,7 +26,7 @@ public class Review {
     @NotNull
     private Double rating;
 
-    @Column(name = "createdAt")
+    @Column(name = "created_at")
     @NotNull
     private LocalDateTime createdAt;
 
@@ -40,3 +40,4 @@ public class Review {
     @NotNull
     private Instructor instructor;
 }
+

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/review/ReviewRepository.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/review/ReviewRepository.java
@@ -1,7 +1,12 @@
 package com.drivingtoday.domain.review;
 
 import com.drivingtoday.domain.review.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Page<Review> findAllByInstructorId(Long instructorId, Pageable pageable);
 }
+

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/review/ReviewRepository.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/review/ReviewRepository.java
@@ -1,12 +1,7 @@
 package com.drivingtoday.domain.review;
 
-import com.drivingtoday.domain.review.Review;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-
-    Page<Review> findAllByInstructorId(Long instructorId, Pageable pageable);
 }
 

--- a/backend/driving-today/src/main/resources/data.sql
+++ b/backend/driving-today/src/main/resources/data.sql
@@ -1,0 +1,53 @@
+INSERT INTO Academy (name, latitude, longitude, cert)
+VALUES
+    ('Academy 1', 37.12345, -122.6789, true),
+    ('Academy 2', 37.54321, -122.9876, false),
+    ('Academy 3', 37.98765, -122.3456, true),
+    ('Academy 4', 37.45678, -122.1234, false),
+    ('Academy 5', 37.87654, -122.5432, true),
+    ('Academy 6', 37.23456, -122.8765, false),
+    ('Academy 7', 37.65432, -122.2345, true),
+    ('Academy 8', 37.34567, -122.5678, false),
+    ('Academy 9', 37.78901, -122.4321, true),
+    ('Academy 10', 37.01234, -122.7890, false);
+
+
+INSERT INTO Student (name, phone_number, student_image, nickname)
+VALUES
+    ('John Doe', '010-1234-5678', 'http://example.com/image1.jpg', 'Johny'),
+    ('Jane Smith', '010-9876-5432', 'http://example.com/image2.jpg', 'Janey'),
+    ('David Lee', '010-5678-1234', 'http://example.com/image3.jpg', 'Dave'),
+    ('Emma Johnson', '010-4321-8765', 'http://example.com/image4.jpg', 'Emmy'),
+    ('Michael Brown', '010-8765-4321', 'http://example.com/image5.jpg', 'Mike'),
+    ('Jessica Kim', '010-3456-7890', 'http://example.com/image6.jpg', 'Jess'),
+    ('Daniel Park', '010-6543-2109', 'http://example.com/image7.jpg', 'Danny'),
+    ('Sophia Lee', '010-2109-8765', 'http://example.com/image8.jpg', 'Sophie'),
+    ('Matthew Choi', '010-7890-1234', 'http://example.com/image9.jpg', 'Matt'),
+    ('Olivia Jung', '010-8901-3456', 'http://example.com/image10.jpg', 'Liv');
+
+
+INSERT INTO Instructor (name, phone_number, instructor_image, price_per_hour, introduction, academy_id)
+VALUES
+    ('Instructor 1', '010-1111-1111', 'instructor_image_1.jpg', 50000, 'Introduction 1', 1),
+    ('Instructor 2', '010-2222-2222', 'instructor_image_2.jpg', 55000, 'Introduction 2', 2),
+    ('Instructor 3', '010-3333-3333', 'instructor_image_3.jpg', 60000, 'Introduction 3', 3),
+    ('Instructor 4', '010-4444-4444', 'instructor_image_4.jpg', 65000, 'Introduction 4', 4),
+    ('Instructor 5', '010-5555-5555', 'instructor_image_5.jpg', 70000, 'Introduction 5', 5),
+    ('Instructor 6', '010-6666-6666', 'instructor_image_6.jpg', 75000, 'Introduction 6', 6),
+    ('Instructor 7', '010-7777-7777', 'instructor_image_7.jpg', 80000, 'Introduction 7', 7),
+    ('Instructor 8', '010-8888-8888', 'instructor_image_8.jpg', 85000, 'Introduction 8', 8),
+    ('Instructor 9', '010-9999-9999', 'instructor_image_9.jpg', 90000, 'Introduction 9', 9),
+    ('Instructor 10', '010-0000-0000', 'instructor_image_10.jpg', 95000, 'Introduction 10', 10);
+
+INSERT INTO Review (contents, rating, created_at, student_id, instructor_id)
+VALUES
+    ('Great instructor!', 4.5, '2024-02-08 10:00:00', 1, 1),
+    ('Excellent teaching skills!', 5.0, '2024-02-08 11:00:00', 2, 1),
+    ('Very patient and knowledgeable', 4.8, '2024-02-08 12:00:00', 3, 1),
+    ('Could improve communication', 3.5, '2024-02-08 13:00:00', 4, 1),
+    ('Highly recommend!', 4.9, '2024-02-08 14:00:00', 5, 1),
+    ('Amazing experience!', 5.0, '2024-02-08 15:00:00', 6, 1),
+    ('Good instructor overall', 4.0, '2024-02-08 16:00:00', 7, 1),
+    ('Very informative lessons', 4.7, '2024-02-08 17:00:00', 8, 1),
+    ('Friendly and approachable', 4.6, '2024-02-08 18:00:00', 9, 1),
+    ('Could be more punctual', 3.8, '2024-02-08 19:00:00', 10, 1);

--- a/backend/driving-today/src/main/resources/data.sql
+++ b/backend/driving-today/src/main/resources/data.sql
@@ -51,3 +51,8 @@ VALUES
     ('Very informative lessons', 4.7, '2024-02-08 17:00:00', 8, 1),
     ('Friendly and approachable', 4.6, '2024-02-08 18:00:00', 9, 1),
     ('Could be more punctual', 3.8, '2024-02-08 19:00:00', 10, 1);
+
+INSERT INTO RESERVATION(is_accepted, reservation_date, reservation_time, training_time, created_at, instructor_id, student_id)
+VALUES
+    (1, '2024-02-11', 14, 2, '2024-02-11 15:30:00', 1, 1),
+    (1, '2024-02-20', 10, 1, '2024-01-11 20:14:30', 7, 3);

--- a/backend/driving-today/src/test/java/com/drivingtoday/domain/instructor/InstructorFindServiceTest.java
+++ b/backend/driving-today/src/test/java/com/drivingtoday/domain/instructor/InstructorFindServiceTest.java
@@ -29,4 +29,30 @@ public class InstructorFindServiceTest {
         InstructorDetailResponse response = instructorFindService.findInstructor(2L, 1, 1);
         assertThat(response.getReviews()).isEmpty();
     }
+
+    @Test
+    @DisplayName("저장된 10개의 리뷰를 5개씩 2page로 나눠지는지 테스트")
+    public void 페이징_테스트1() {
+        InstructorDetailResponse response1 = instructorFindService.findInstructor(1L, 1, 5);
+        assertThat(response1.getReviews().size()).isEqualTo(5);
+
+        InstructorDetailResponse response2 = instructorFindService.findInstructor(1L, 2, 5);
+        assertThat(response2.getReviews().size()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("저장된 10개의 리뷰를 3개씩 3page + 1개 1page로 나눠지는지 테스트")
+    public void 페이징_테스트2() {
+        InstructorDetailResponse response1 = instructorFindService.findInstructor(1L, 1, 3);
+        assertThat(response1.getReviews().size()).isEqualTo(3);
+
+        InstructorDetailResponse response2 = instructorFindService.findInstructor(1L, 2, 3);
+        assertThat(response2.getReviews().size()).isEqualTo(3);
+
+        InstructorDetailResponse response3 = instructorFindService.findInstructor(1L, 3, 3);
+        assertThat(response3.getReviews().size()).isEqualTo(3);
+
+        InstructorDetailResponse response4 = instructorFindService.findInstructor(1L, 4, 3);
+        assertThat(response4.getReviews().size()).isEqualTo(1);
+    }
 }

--- a/backend/driving-today/src/test/java/com/drivingtoday/domain/instructor/InstructorFindServiceTest.java
+++ b/backend/driving-today/src/test/java/com/drivingtoday/domain/instructor/InstructorFindServiceTest.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -17,8 +19,17 @@ public class InstructorFindServiceTest {
     @Autowired InstructorFindService instructorFindService;
 
     @Test
+    @DisplayName("존재하지 않는 강사id로 조회된 경우 예외 발생")
+    public void 없는_강사_조회_테스트() {
+        RuntimeException e = assertThrows(RuntimeException.class, () -> {
+            instructorFindService.findInstructor(13L, 1, 5);
+        });
+        assertThat("해당 강사가 존재하지 않습니다.").isEqualTo(e.getMessage());
+    }
+
+    @Test
     @DisplayName("ID가 1인 강사의 리뷰를 조회하면 모든 리뷰(10개) 리스트가 반환된다")
-    public void 기본_조회_테스트() {
+    public void 기본_리뷰_조회_테스트() {
         InstructorDetailResponse response = instructorFindService.findInstructor(1L, 1, 10);
         assertThat(response.getReviews().size()).isEqualTo(10);
     }

--- a/backend/driving-today/src/test/java/com/drivingtoday/domain/instructor/InstructorFindServiceTest.java
+++ b/backend/driving-today/src/test/java/com/drivingtoday/domain/instructor/InstructorFindServiceTest.java
@@ -22,48 +22,9 @@ public class InstructorFindServiceTest {
     @DisplayName("존재하지 않는 강사id로 조회된 경우 예외 발생")
     public void 없는_강사_조회_테스트() {
         RuntimeException e = assertThrows(RuntimeException.class, () -> {
-            instructorFindService.findInstructor(13L, 1, 5);
+            instructorFindService.findInstructor(13L);
         });
         assertThat("해당 강사가 존재하지 않습니다.").isEqualTo(e.getMessage());
     }
 
-    @Test
-    @DisplayName("ID가 1인 강사의 리뷰를 조회하면 모든 리뷰(10개) 리스트가 반환된다")
-    public void 기본_리뷰_조회_테스트() {
-        InstructorDetailResponse response = instructorFindService.findInstructor(1L, 1, 10);
-        assertThat(response.getReviews().size()).isEqualTo(10);
-    }
-
-    @Test
-    @DisplayName("리뷰가 하나도 없는 강사를 조회할 경우 빈 리스트가 반환된다")
-    public void 리뷰없는_강사_조회_테스트() {
-        InstructorDetailResponse response = instructorFindService.findInstructor(2L, 1, 1);
-        assertThat(response.getReviews()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("저장된 10개의 리뷰를 5개씩 2page로 나눠지는지 테스트")
-    public void 페이징_테스트1() {
-        InstructorDetailResponse response1 = instructorFindService.findInstructor(1L, 1, 5);
-        assertThat(response1.getReviews().size()).isEqualTo(5);
-
-        InstructorDetailResponse response2 = instructorFindService.findInstructor(1L, 2, 5);
-        assertThat(response2.getReviews().size()).isEqualTo(5);
-    }
-
-    @Test
-    @DisplayName("저장된 10개의 리뷰를 3개씩 3page + 1개 1page로 나눠지는지 테스트")
-    public void 페이징_테스트2() {
-        InstructorDetailResponse response1 = instructorFindService.findInstructor(1L, 1, 3);
-        assertThat(response1.getReviews().size()).isEqualTo(3);
-
-        InstructorDetailResponse response2 = instructorFindService.findInstructor(1L, 2, 3);
-        assertThat(response2.getReviews().size()).isEqualTo(3);
-
-        InstructorDetailResponse response3 = instructorFindService.findInstructor(1L, 3, 3);
-        assertThat(response3.getReviews().size()).isEqualTo(3);
-
-        InstructorDetailResponse response4 = instructorFindService.findInstructor(1L, 4, 3);
-        assertThat(response4.getReviews().size()).isEqualTo(1);
-    }
 }

--- a/backend/driving-today/src/test/java/com/drivingtoday/domain/instructor/InstructorFindServiceTest.java
+++ b/backend/driving-today/src/test/java/com/drivingtoday/domain/instructor/InstructorFindServiceTest.java
@@ -1,0 +1,32 @@
+package com.drivingtoday.domain.instructor;
+
+import com.drivingtoday.domain.instructor.dto.InstructorDetailResponse;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class InstructorFindServiceTest {
+
+    @Autowired InstructorFindService instructorFindService;
+
+    @Test
+    @DisplayName("ID가 1인 강사의 리뷰를 조회하면 모든 리뷰(10개) 리스트가 반환된다")
+    public void 기본_조회_테스트() {
+        InstructorDetailResponse response = instructorFindService.findInstructor(1L, 1, 10);
+        assertThat(response.getReviews().size()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("리뷰가 하나도 없는 강사를 조회할 경우 빈 리스트가 반환된다")
+    public void 리뷰없는_강사_조회_테스트() {
+        InstructorDetailResponse response = instructorFindService.findInstructor(2L, 1, 1);
+        assertThat(response.getReviews()).isEmpty();
+    }
+}


### PR DESCRIPTION
## 구현 내용

- close #50 
- 특정 강사 id로 강사의 정보, 강사가 소속된 학원 정보, 강사에 대한 리뷰 목록을 반환하는 API 개발
- 리뷰에 대한 페이징 기능 구현, 리뷰가 작성된 날짜 순(최신 순)으로 리뷰를 정렬하여 반환 
- data.sql에 review 10개 insert하는 쿼리 추가
- 클라이언트 화면에서 필요로 하는 정보들 기준으로 전부 DTO 분리

## 고민 사항
- 응답을 생성하는 시점에 LAZY_LOADING으로 인해 HttpMessageConverter가 응답을 생성하지 못하는 경우가 발생 -> DTO를 정보 별로 분리하고 해당 DTO에서 직접 getter를 호출하는 식으로 해결
- 기존 dev브랜치 테스트 폴더 구조를 안바꿔 놔서 수정이 필요할듯
- 양방향 매핑이 없으니 instructor 관련된 코드임에도 리뷰를 가져오는 과정에서 ReviewRepository에 대해 쿼리가 나가서 테스트 코드 도메인 분리가 굉장히 애매해짐 -> 양방향 매핑을 최대한 안하려고 했는데 도입이 필요할 것 같기도 함. 필요한 상황을 확실히 공부할 필요가 있겠다.

## 기타
