### PR TITLE
[FE] feat: checkbox component

### DIFF
--- a/frontend/src/components/checkbox/README.md
+++ b/frontend/src/components/checkbox/README.md
@@ -2,7 +2,7 @@
 
 - checkbox 컴포넌트
 - `<input type='checkbox' />`에 대한 스타일 적용
-- controlled / uncontrolled 방식 모두 지원
+- `ref`를 넘겨줘 input DOM 노드의 focus 상태 부모 컴포넌트에서 조작할 수 있도록 함
 
 ## props
 
@@ -15,10 +15,8 @@ type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
 ```tsx
 <Checkbox defaultChecked />
 
-// controlled
 <Checkbox checked={checked} onChange={() => setChecked((prev) => !prev)} />
 
-// uncontrolled
 <Checkbox ref={checkboxRef} />
 
 // disabled

--- a/frontend/src/components/checkbox/README.md
+++ b/frontend/src/components/checkbox/README.md
@@ -20,4 +20,8 @@ type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
 
 // uncontrolled
 <Checkbox ref={checkboxRef} />
+
+// disabled
+<Checkbox checked disabled />
+<Checkbox disabled />
 ```

--- a/frontend/src/components/checkbox/README.md
+++ b/frontend/src/components/checkbox/README.md
@@ -1,0 +1,23 @@
+## description
+
+- checkbox 컴포넌트
+- `<input type='checkbox' />`에 대한 스타일 적용
+- controlled / uncontrolled 방식 모두 지원
+
+## props
+
+```tsx
+type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
+```
+
+## use case
+
+```tsx
+<Checkbox defaultChecked />
+
+// controlled
+<Checkbox checked={checked} onChange={() => setChecked((prev) => !prev)} />
+
+// uncontrolled
+<Checkbox ref={checkboxRef} />
+```

--- a/frontend/src/components/checkbox/checkbox.tsx
+++ b/frontend/src/components/checkbox/checkbox.tsx
@@ -59,4 +59,16 @@ const Input = styled.input(({theme}) => ({
     backgroundColor: `${theme.color.primary}`,
     borderRadius: '0.3rem',
   },
+
+  '&:checked:disabled + span': {
+    border: 0,
+  },
+
+  '&:disabled + span': {
+    border: `2px solid ${theme.color.gray400}`,
+  },
+
+  '&:checked:disabled + span::after': {
+    backgroundColor: `${theme.color.gray400}`,
+  },
 }))

--- a/frontend/src/components/checkbox/checkbox.tsx
+++ b/frontend/src/components/checkbox/checkbox.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled'
+import React, {InputHTMLAttributes} from 'react'
+
+export type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
+
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  props,
+  forwardedRef,
+) {
+  return (
+    <Container>
+      <Input ref={forwardedRef} type="checkbox" {...props} />
+      <span aria-hidden="true" />
+    </Container>
+  )
+})
+
+const Container = styled.span(() => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  position: 'relative',
+  border: 0,
+  outline: 0,
+  userSelect: 'none',
+  cursor: 'pointer',
+  padding: '1rem',
+}))
+
+const Input = styled.input(({theme}) => ({
+  position: 'absolute',
+  inset: 0,
+  opacity: 0,
+  cursor: 'inherit',
+  zIndex: 1,
+  '& + span': {
+    position: 'relative',
+    display: 'inline-block',
+    border: `2px solid ${theme.color.gray700}`,
+    width: '1.8rem',
+    height: '1.8rem',
+    borderRadius: '0.3rem',
+  },
+
+  '&:checked + span': {
+    border: 0,
+  },
+
+  '&:checked + span::after': {
+    content: '"✓"',
+    color: `${theme.color.white}`,
+    position: 'absolute',
+    fontSize: '1.5rem',
+    lineHeight: '1.5rem',
+    width: '100%',
+    height: '100%',
+    textAlign: 'center',
+    verticalAlign: 'middle',
+    backgroundColor: `${theme.color.primary}`,
+    borderRadius: '0.3rem',
+  },
+}))

--- a/frontend/src/components/checkbox/checkbox.tsx
+++ b/frontend/src/components/checkbox/checkbox.tsx
@@ -48,7 +48,7 @@ const Input = styled.input(({theme}) => ({
 
   '&:checked + span::after': {
     content: '"✓"',
-    color: `${theme.color.white}`,
+    color: theme.color.white,
     position: 'absolute',
     fontSize: '1.5rem',
     lineHeight: '1.5rem',
@@ -56,7 +56,7 @@ const Input = styled.input(({theme}) => ({
     height: '100%',
     textAlign: 'center',
     verticalAlign: 'middle',
-    backgroundColor: `${theme.color.primary}`,
+    backgroundColor: theme.color.primary,
     borderRadius: '0.3rem',
   },
 
@@ -69,6 +69,6 @@ const Input = styled.input(({theme}) => ({
   },
 
   '&:checked:disabled + span::after': {
-    backgroundColor: `${theme.color.gray400}`,
+    backgroundColor: theme.color.gray400,
   },
 }))

--- a/frontend/src/components/checkbox/index.ts
+++ b/frontend/src/components/checkbox/index.ts
@@ -1,0 +1,2 @@
+export {type CheckboxProps} from './checkbox'
+export {Checkbox} from './checkbox'


### PR DESCRIPTION
## 구현 내용

- close #61 
- checkbox 컴포넌트 작성
- `ref`를 넘겨줘 input DOM 노드의 focus 상태 부모 컴포넌트에서 조작할 수 있도록 함

## 고민 사항

## 기타
- [forwardRef API](https://react.dev/reference/react/forwardRef)