### PR TITLE
[FE] feat: header 컴포넌트 작성

### DIFF
--- a/frontend/src/assets/icons/arrow_back.svg
+++ b/frontend/src/assets/icons/arrow_back.svg
@@ -1,0 +1,8 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_72_4612" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+<rect width="20" height="20" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_72_4612)">
+<path d="M8.33333 18.3332L0 9.99984L8.33333 1.6665L9.8125 3.14567L2.95833 9.99984L9.8125 16.854L8.33333 18.3332Z" fill="#14142B"/>
+</g>
+</svg>

--- a/frontend/src/assets/icons/index.ts
+++ b/frontend/src/assets/icons/index.ts
@@ -1,3 +1,4 @@
+export {default as arrowBack} from './arrow_back.svg'
 export {default as building} from './building.svg'
 export {default as call} from './call.svg'
 export {default as date} from './date.svg'

--- a/frontend/src/components/header/README.md
+++ b/frontend/src/components/header/README.md
@@ -1,0 +1,27 @@
+## description
+
+- header 컴포넌트
+
+## props
+
+| name |          description           | default |
+| :--: | :----------------------------: | :-----: |
+| `px` | padding-left and padding-right |    0    |
+
+## use case
+
+```jsx
+<Header px="20rem">
+  <div style={{display: 'flex', gap: 10}}>
+    <Header.BackButton></Header.BackButton>
+    <Header.Logo></Header.Logo>
+  </div>
+  {/* ⬇️ The element that only occupy the space in between */}
+  <div style={{flexGrow: '1'}} />
+  <div style={{display: 'flex'}}>
+    <Notification />
+    <Avartar />
+    <Menu />
+  </div>
+</Header>
+```

--- a/frontend/src/components/header/header.tsx
+++ b/frontend/src/components/header/header.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled'
+import type {CSSProperties, HTMLAttributes, PropsWithChildren} from 'react'
+
+import {Button} from '../button'
+
+interface HeaderProps extends HTMLAttributes<HTMLElement>, StyledHeaderProps {}
+export function Header({children, ...props}: PropsWithChildren<HeaderProps>) {
+  return <StyledHeader {...props}>{children}</StyledHeader>
+}
+
+function HeaderBackButton() {
+  return <Button bgColor="white">back</Button>
+}
+
+type HeaderBoxProps = HTMLAttributes<HTMLDivElement>
+function HeaderBox({children, ...props}: PropsWithChildren<HeaderBoxProps>) {
+  return <div {...props}>{children}</div>
+}
+
+interface StyledHeaderProps {
+  px?: CSSProperties['padding']
+}
+const StyledHeader = styled.header<StyledHeaderProps>(({px, theme}) => ({
+  position: 'sticky',
+  top: 0,
+  left: 0,
+  display: 'flex',
+  alignItems: 'center',
+  height: '8rem',
+  width: '100%',
+  paddingLeft: px,
+  paddingRight: px,
+  backgroundColor: theme.color.white,
+  borderBottom: `1px solid ${theme.color.gray200}`,
+}))
+
+Header.BackButton = HeaderBackButton
+Header.Box = HeaderBox

--- a/frontend/src/components/header/header.tsx
+++ b/frontend/src/components/header/header.tsx
@@ -1,22 +1,17 @@
 import styled from '@emotion/styled'
 import type {CSSProperties, HTMLAttributes, PropsWithChildren} from 'react'
 
-import {Button} from '../button'
+import {Button, type ButtonProps} from '@/components/button'
+import {Icon} from '@/components/icon'
 
 interface HeaderProps extends HTMLAttributes<HTMLElement>, StyledHeaderProps {}
-export function Header({children, ...props}: PropsWithChildren<HeaderProps>) {
-  return <StyledHeader {...props}>{children}</StyledHeader>
+export function Header({children, px = 0, ...props}: PropsWithChildren<HeaderProps>) {
+  return (
+    <StyledHeader px={px} {...props}>
+      {children}
+    </StyledHeader>
+  )
 }
-
-function HeaderBackButton() {
-  return <Button bgColor="white">back</Button>
-}
-
-type HeaderBoxProps = HTMLAttributes<HTMLDivElement>
-function HeaderBox({children, ...props}: PropsWithChildren<HeaderBoxProps>) {
-  return <div {...props}>{children}</div>
-}
-
 interface StyledHeaderProps {
   px?: CSSProperties['padding']
 }
@@ -34,5 +29,20 @@ const StyledHeader = styled.header<StyledHeaderProps>(({px, theme}) => ({
   borderBottom: `1px solid ${theme.color.gray200}`,
 }))
 
+type HeaderBackButtonProps = Omit<ButtonProps, 'color' | 'bgColor'>
+function HeaderBackButton(props: HeaderBackButtonProps) {
+  return (
+    <BackButton {...props} bgColor="white">
+      <Icon name="arrowBack" color="gray900" width="2.4rem" height="2.4rem" />
+      <div>뒤로 가기</div>
+    </BackButton>
+  )
+}
+const BackButton = styled(Button)(({theme}) => ({
+  display: 'flex',
+  color: theme.color.gray900,
+  alignItems: 'center',
+  justifyContent: 'center',
+}))
+
 Header.BackButton = HeaderBackButton
-Header.Box = HeaderBox

--- a/frontend/src/components/header/index.ts
+++ b/frontend/src/components/header/index.ts
@@ -1,0 +1,1 @@
+export {Header} from './header'


### PR DESCRIPTION
## 구현 내용

- close #70 
- Header 컴포넌트 작성

## 고민 사항

- Header 컴포넌트는 단지 `display: 'flex'`, `position: 'sticky'` 속성만 가지고 있고 Header children 에서 스타일을 주입해주어야 함
```jsx
<Header px="20rem">
  <div style={{display: 'flex', gap: 10}}>
    <Header.BackButton></Header.BackButton>
    <Header.Logo></Header.Logo>
  </div>
  {/* ⬇️ The element that only occupy the space in between */}
  <div style={{flexGrow: '1'}} />
  <div style={{display: 'flex'}}>
    <Notification />
    <Avartar />
    <Menu />
  </div>
</Header>
```

## 기타
