### PR TITLE
[FE] feat: instructor detail dialog

### DIFF
--- a/frontend/src/pages/search/components/detail-dialog.tsx
+++ b/frontend/src/pages/search/components/detail-dialog.tsx
@@ -1,0 +1,181 @@
+import {Theme} from '@emotion/react'
+import styled from '@emotion/styled'
+import {CSSProperties} from 'react'
+
+import {Button} from '@/components/button'
+import {Divider} from '@/components/divider'
+import {Icon} from '@/components/icon'
+import {Rating} from '@/components/rating'
+
+import {detailData, reviewData} from '../data'
+
+interface DetailDialogProps {
+  id: number
+  onClose: () => void
+}
+export function DetailDialog({id, onClose}: DetailDialogProps) {
+  return (
+    <Dialog>
+      <DialogHeader>
+        <Typograpy as="h1" color="gray900" size="2rem" weight="bold">
+          강사 상세 정보
+        </Typograpy>
+        <Icon
+          name="close"
+          width="1.4rem"
+          height="1.4rem"
+          color="gray900"
+          onClick={onClose}
+          style={{cursor: 'pointer'}}
+        >
+          닫기
+        </Icon>
+      </DialogHeader>
+      <DialogContent>
+        <InstructorDetail id={id} />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const Dialog = styled.div(() => ({
+  position: 'absolute',
+  left: '105%',
+  top: '2rem',
+  width: '35rem',
+  height: '90%',
+  backgroundColor: 'white',
+  borderRadius: '1.6rem',
+  boxShadow: '5px 5px 5px 0px rgb(0 0 0 / 15%)',
+  display: 'flex',
+  flexDirection: 'column',
+}))
+
+const DialogHeader = styled.div(() => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '2rem',
+}))
+
+const DialogContent = styled.div(() => ({
+  padding: '0 2rem 0',
+  height: '100%',
+  flex: '1 1 0',
+  overflowY: 'scroll',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+}))
+
+function InstructorDetail({id}: {id: number}) {
+  // TODO: 상세 정보, 리뷰 리스트 받아오기(무한스크롤)
+  return (
+    <>
+      <Flex as="section" gap="1rem" flexDirection="column">
+        <Flex gap="2rem" flexDirection="row" alignItems="center">
+          <Avartar src={detailData.instructorInfo.instructorImage} width="62" height="62" />
+          <Typograpy color="gray700" size="2rem" weight="bold">
+            {detailData.instructorInfo.name}
+          </Typograpy>
+        </Flex>
+        <Flex as="ul">
+          <Typograpy as="li" color="gray600" weight="500" size="1.4rem">
+            평점 4.5
+          </Typograpy>
+          <Divider orientation="vertical" flexItem style={{margin: '0.5rem'}} />
+          <Typograpy as="li" color="gray600" weight="500" size="1.4rem">
+            시간당 {detailData.instructorInfo.pricePerHour.toLocaleString()}
+          </Typograpy>
+        </Flex>
+        <Flex alignItems="center">
+          <Icon name="building" width="2rem" height="2rem" color="gray600" />
+          <Typograpy as="span" color="gray600" weight="500" size="1.4rem">
+            {detailData.academyInfo.name}
+          </Typograpy>
+        </Flex>
+        <Actions>
+          <Button>문의</Button>
+          <Button>예약</Button>
+        </Actions>
+      </Flex>
+      <Divider />
+      <Flex as="section" flexDirection="column" gap="1rem">
+        <Typograpy as="h1" color="gray600" size="1.6rem" weight="bold">
+          강사 소개
+        </Typograpy>
+        <Typograpy as="p" color="gray900" weight="500" size="1.4rem">
+          {detailData.instructorInfo.introduction}
+        </Typograpy>
+      </Flex>
+      <Divider />
+      <Flex as="section" flexDirection="column" gap="1rem">
+        <Typograpy as="h1" color="gray600" size="1.6rem" weight="bold">
+          리뷰
+        </Typograpy>
+        <Flex as="ul" gap="2.5rem" flexDirection="column" style={{paddingBottom: '4rem'}}>
+          {reviewData.map((review) => (
+            <Flex as="li" flexDirection="column" gap="1.5rem" key={review.reviewId}>
+              <Flex gap="1rem" alignItems="center">
+                <Avartar src={detailData.instructorInfo.instructorImage} width="30" height="30" />
+                <Typograpy color="gray900" size="1.4rem" weight="bold">
+                  {detailData.instructorInfo.name}
+                </Typograpy>
+              </Flex>
+              <Flex justifyContent="space-between">
+                <Rating defaultValue={review.rating} readOnly />
+                <Typograpy as="span" color="gray600" size="1.4rem" weight="500">
+                  {new Date(review.createdAt).toLocaleDateString('ko-KR')}
+                </Typograpy>
+              </Flex>
+              <Typograpy as="p" color="gray900" size="1.4rem" weight="500">
+                {review.contents}
+              </Typograpy>
+            </Flex>
+          ))}
+        </Flex>
+      </Flex>
+    </>
+  )
+}
+
+type FlexProps = Pick<
+  CSSProperties,
+  'justifyContent' | 'alignItems' | 'flexDirection' | 'flexWrap' | 'flexGrow' | 'gap'
+>
+const Flex = styled.div<FlexProps>(
+  ({justifyContent, alignItems, flexDirection, flexGrow, flexWrap, gap}) => ({
+    display: 'flex',
+    justifyContent,
+    alignItems,
+    flexDirection,
+    flexGrow,
+    flexWrap,
+    gap,
+  }),
+)
+
+const Typograpy = styled.span<{
+  color: keyof Theme['color']
+  size: CSSProperties['fontSize']
+  weight: CSSProperties['fontWeight']
+}>(({theme, color, size, weight}) => ({
+  color: theme.color[color],
+  fontSize: size,
+  fontWeight: weight,
+}))
+
+const Avartar = styled.img(({width, height}) => ({
+  borderRadius: '50%',
+  width,
+  height,
+}))
+
+const Actions = styled.div(() => ({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '0.5rem',
+  '& > button': {
+    width: 'auto',
+  },
+}))

--- a/frontend/src/pages/search/components/index.ts
+++ b/frontend/src/pages/search/components/index.ts
@@ -1,1 +1,2 @@
+export * from './detail-dialog'
 export * from './search-preview'

--- a/frontend/src/pages/search/components/search-preview.tsx
+++ b/frontend/src/pages/search/components/search-preview.tsx
@@ -33,7 +33,7 @@ const StyledLink = styled(Link)(({theme}) => ({
   borderRadius: '0.8rem',
   backgroundColor: theme.color.white,
   padding: '2rem 0',
-  marginBottom: '2rem',
+  margin: '2rem 0',
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',

--- a/frontend/src/pages/search/data.ts
+++ b/frontend/src/pages/search/data.ts
@@ -110,3 +110,99 @@ export const dummydata = [
     academyName: '강남차동자전운문전학원',
   },
 ]
+
+export const detailData = {
+  instructorInfo: {
+    id: 10,
+    name: '오정진',
+    phoneNumber: '010-1234-5678',
+    instructorImage: 'https://picsum.photos/200',
+    pricePerHour: 12000,
+    introduction:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus a fringilla est, at vulputate quam. Proin eget quam sed nulla vehicula vulputate.',
+  },
+  academyInfo: {
+    name: '강남차동자전운문전학원',
+    latitude: 37.492,
+    longitude: 127.012,
+    cert: true,
+  },
+}
+
+export const reviewData = [
+  {
+    reviewId: 57,
+    contents:
+      '서비스가 매우 만족스럽습니다. 친절한 강사와 효과적인 수업이었습니다. 다만 시설이 조금 낡아서 아쉬웠어요.',
+    rating: 4,
+    createdAt: '2024-02-14T17:13:58.586Z',
+    reviewerName: '이지수',
+  },
+  {
+    reviewId: 26,
+    contents:
+      '교육 내용은 훌륭하지만 강사의 태도가 별로였습니다. 고칠 점이 많아 보입니다. 시설은 깨끗하고 좋았습니다.',
+    rating: 2.5,
+    createdAt: '2024-02-14T17:13:58.586Z',
+    reviewerName: '김준희',
+  },
+  {
+    reviewId: 83,
+    contents:
+      '매우 만족스러운 수업이었습니다. 강사님의 친절한 설명과 배려가 돋보였습니다. 시설도 깨끗하고 좋았습니다.',
+    rating: 5,
+    createdAt: '2024-02-14T17:13:58.586Z',
+    reviewerName: '서지원',
+  },
+  {
+    reviewId: 39,
+    contents: '수업은 만족스러웠지만 시설이 조금 협소해서 불편했습니다. 강사님은 친절하셨습니다.',
+    rating: 3.5,
+    createdAt: '2024-02-14T17:13:58.586Z',
+    reviewerName: '홍정희',
+  },
+  {
+    reviewId: 74,
+    contents: '수업은 효과적이었으나 강사의 태도가 별로였습니다. 더 좋은 서비스를 원합니다.',
+    rating: 2,
+    createdAt: '2024-02-14T17:13:58.586Z',
+    reviewerName: '김준희',
+  },
+  {
+    reviewId: 10,
+    contents:
+      '전반적으로 좋았습니다. 하지만 수업 시간이 너무 짧았어요. 좀 더 긴 시간으로 수업을 받고 싶었습니다.',
+    rating: 4.5,
+    createdAt: '2024-02-14T17:13:58.586Z',
+    reviewerName: '이지수',
+  },
+  {
+    reviewId: 92,
+    contents: '수업은 매우 만족스럽습니다. 친절한 강사님과 좋은 시설을 제공해 주셔서 감사합니다.',
+    rating: 5,
+    createdAt: '2024-02-14T17:13:58.586Z',
+    reviewerName: '홍정희',
+  },
+  {
+    reviewId: 69,
+    contents:
+      '서비스가 좋았습니다. 하지만 수업 시간이 너무 짧아서 아쉬웠습니다. 더 긴 시간으로 수업을 받고 싶었습니다.',
+    rating: 4,
+    createdAt: '2024-02-14T17:13:58.586Z',
+    reviewerName: '서지원',
+  },
+  {
+    reviewId: 5,
+    contents: '전반적으로 만족스러운 수업이었습니다. 강사님의 친절함에 감사드립니다.',
+    rating: 4,
+    createdAt: '2024-02-14T17:13:58.586Z',
+    reviewerName: '김준희',
+  },
+  {
+    reviewId: 31,
+    contents: '강사님의 설명이 너무 어려웠습니다. 좀 더 쉽게 설명해 주셨으면 좋겠습니다.',
+    rating: 2.5,
+    createdAt: '2024-02-14T17:13:58.586Z',
+    reviewerName: '이지수',
+  },
+]

--- a/frontend/src/pages/search/page.tsx
+++ b/frontend/src/pages/search/page.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import {useRef, useState} from 'react'
 import {Map, MapMarker, MarkerClusterer} from 'react-kakao-maps-sdk'
 import {useNavigate, useSearchParams} from 'react-router-dom'
 
@@ -6,12 +7,14 @@ import {Card} from '@/components/card'
 import {Divider} from '@/components/divider'
 import {Header} from '@/components/header'
 
-import {SearchPreview} from './components'
+import {DetailDialog, SearchPreview} from './components'
 import {dummydata} from './data'
 
 export function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
+  const mapRef = useRef<kakao.maps.Map | null>(null)
+  const [selectedId, setSelectedId] = useState<number | null>(null)
 
   // TODO: searchParms 가 모두 있는지 확인, 없다면 이전 페이지로 redirect
   const trainingTime = Number(searchParams.get('trainingTime'))
@@ -29,8 +32,8 @@ export function SearchPage() {
           </div>
         </Header>
 
-        <H1>강사 선택</H1>
         <Box>
+          <H1>강사 선택</H1>
           <SearchPreview />
           <Divider />
         </Box>
@@ -44,10 +47,16 @@ export function SearchPage() {
               pricePerHour={instructor.pricePerHour}
               distance={instructor.distance}
               duration={2}
-              rating={2}
+              rating={5}
+              onClick={() => {
+                const latlng = new kakao.maps.LatLng(instructor.latitude, instructor.longitude)
+                mapRef.current?.panTo(latlng)
+                setSelectedId(instructor.instructorId)
+              }}
             />
           ))}
         </InstructorList>
+        {selectedId && <DetailDialog id={selectedId} onClose={() => setSelectedId(null)} />}
       </SearchResultContainer>
 
       <Map
@@ -60,6 +69,8 @@ export function SearchPage() {
           width: '100%',
           height: '100%',
         }}
+        isPanto
+        ref={mapRef}
         level={3}
         onDragEnd={(map) => {
           const latlng = map.getCenter()
@@ -95,8 +106,9 @@ export function SearchPage() {
 }
 
 const SearchResultContainer = styled.section(() => ({
+  position: 'relative',
   width: '30%',
-  minWidth: '60rem',
+  minWidth: '45rem',
   height: '100%',
   boxShadow: '5px 1px 5px 0px rgb(0 0 0 / 10%)',
   // NOTE: box-shodow 스타일을 적용하기 위해 지도의 z index 보다 높힘
@@ -110,7 +122,6 @@ const H1 = styled.h1(({theme}) => ({
   backgroundColor: theme.color.white,
   fontWeight: 'bold',
   fontSize: '2rem',
-  padding: '2rem',
 }))
 
 const Box = styled.div(() => ({


### PR DESCRIPTION
## 구현 내용

- close #114 

## 고민 사항

- https://github.com/softeerbootcamp-3rd/Team1-driving-today/commit/732def2e1ce4a6ca6b3cb29950560109292da974 에서 `Flex`, `Typography` 컴포넌트를 제작했습니다. 해당 컴포넌트들을 공통 컴포넌트로 분리해보면 좋을것 같습니다.
`flex`, `grid` 와 같은 레이아웃이나 폰트 스타일만 가지는 styled 컴포넌트가 반복되고, 이런 컴포넌트에 유의미한 네이밍을 해주기 어려웠습니다. `Container`, `Wrapper`, `BaseContainer`, `Title` 등 껍데기만 담당하는 컴포넌트가 계속 생기고 있습니다. 차라리 레이아웃과 폰트만 담당하는 컴포넌트를 만들어 반복되는 styled 컴포넌트 제작을 줄일 수 있도록 하고자 합니다.
`Flex`, `Typography` 컴포넌트의 `props` 는 css 속성을 반영하여 설계해보았습니다. **그 이유는 css 속성은 개발자에게 익숙하고 이는 직관적이고 어떤 역할을 하는지 바로 알 수 있도록 해주기 때문입니다.**
```jsx
<Flex gap='1rem' justifyContents='center' alignItems='center' flexDirection='column'>
  ....
</Flex>

<Typography color='' weight='bold' size='1.6rem'>
  ....
<Typography>
```


## 기타
