### PR TITLE
hotfix: LocalDateTime이 응답메시지에서 배열로 보이는 문제 해결

### DIFF
--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/reservation/ReservationController.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/reservation/ReservationController.java
@@ -37,7 +37,6 @@ public class ReservationController {
     @Operation(summary = "학생이 본인 예약리스트 확인하기 API")
     public ResponseEntity<List<ReservationStudentResponse>> reservationList(@RequestParam("pageNumber") Integer pageNumber,
                                                                            @RequestParam("pageSize") Integer pageSize){
-        System.out.println("id : " + JwtFilter.getAuthentication().getId());
         List<ReservationStudentResponse> allStudentReservation =
                 reservationListService.findAllStudentReservation(JwtFilter.getAuthentication().getId(), pageNumber, pageSize);
         return ResponseEntity.ok(allStudentReservation);

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/reservation/dto/ReservationInstructorResponse.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/reservation/dto/ReservationInstructorResponse.java
@@ -1,6 +1,7 @@
 package com.drivingtoday.domain.reservation.dto;
 
 import com.drivingtoday.domain.reservation.Reservation;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.cglib.core.Local;
@@ -16,6 +17,7 @@ public class ReservationInstructorResponse {
     private String studentImage;
     private String studentName;
     private String phoneNumber;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate reservationDate;
     private Integer reservationTime;
     private Integer trainingTime;

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/reservation/dto/ReservationStudentResponse.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/reservation/dto/ReservationStudentResponse.java
@@ -1,6 +1,7 @@
 package com.drivingtoday.domain.reservation.dto;
 
 import com.drivingtoday.domain.reservation.Reservation;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,6 +14,7 @@ public class ReservationStudentResponse {
     private String instructorImage;
     private String instructorName;
     private String academyName;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate reservationDate;
     private Integer reservationTime;
     private Integer trainingTime;

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/review/dto/ReviewInfo.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/review/dto/ReviewInfo.java
@@ -1,6 +1,7 @@
 package com.drivingtoday.domain.review.dto;
 
 import com.drivingtoday.domain.review.Review;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,6 +13,7 @@ public class ReviewInfo {
     private Long reviewId;
     private String contents;
     private Double rating;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
     private String reviewerName;
     private String reviewerImage;

--- a/backend/driving-today/src/main/java/com/drivingtoday/global/exception/ExceptionManager.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/global/exception/ExceptionManager.java
@@ -2,10 +2,13 @@ package com.drivingtoday.global.exception;
 
 import com.drivingtoday.domain.reservation.exception.ReservationException;
 import com.drivingtoday.domain.review.exception.ReviewException;
+import com.drivingtoday.global.auth.exception.JwtException;
 import com.drivingtoday.global.user.exception.UserException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
@@ -15,6 +18,7 @@ public class ExceptionManager {
     public ResponseEntity<?> userExceptionHandler(UserException e) {
         log.warn("{}: {}", e.getErrorCode(), e.getMessage());
         return ResponseEntity.status(e.getHttpStatus())
+                .header("Content-Type", "text/plain;charset=UTF-8")
                 .body(e.getErrorCode() + ": " + e.getMessage());
     }
 
@@ -23,20 +27,31 @@ public class ExceptionManager {
     public ResponseEntity<?> reviewExceptionHandler(ReviewException e) {
         log.warn("{}: {}", e.getErrorCode(), e.getMessage());
         return ResponseEntity.status(e.getHttpStatus())
+                .header("Content-Type", "text/plain;charset=UTF-8")
                 .body(e.getErrorCode() + ": " + e.getMessage());
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<?> jwtExceptionHandler(RuntimeException e) {
+    public ResponseEntity<?> ExceptionHandler(RuntimeException e) {
         log.warn("E0000: 알 수 없는 에러가 발생했습니다. - {}", e.getMessage());
         return ResponseEntity.status(500)
+                .header("Content-Type", "text/plain;charset=UTF-8")
                 .body("E0000: 알 수 없는 에러가 발생했습니다.");
     }
 
     @ExceptionHandler(ReservationException.class)
-    public ResponseEntity<?> reviewExceptionHandler(ReservationException e) {
+    public ResponseEntity<?> reservationExceptionHandler(ReservationException e) {
         log.warn("{}: {}", e.getErrorCode(), e.getMessage());
         return ResponseEntity.status(e.getHttpStatus())
+                .header("Content-Type", "text/plain;charset=UTF-8")
+                .body(e.getErrorCode() + ": " + e.getMessage());
+    }
+
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<?> jwtExceptionHandler(JwtException e){
+        log.warn("{}: {}", e.getErrorCode(), e.getMessage());
+        return ResponseEntity.status(e.getHttpStatus())
+                .header("Content-Type", "text/plain;charset=UTF-8")
                 .body(e.getErrorCode() + ": " + e.getMessage());
     }
 }


### PR DESCRIPTION
## 구현 내용

- close #155 
   - GET /rerviews, GET /my/reservations, GET /reservations API에서 LocalDateTime 변수가 배열로 응답되는 문제 해결
   - 에러 응답 메시지 `E000: ? ???? ?` 이런 식으로 한글 깨지는 문제 해결
      -  "Content-Type" 헤더 설정
## 고민 사항

## 기타
