### PR TITLE
[FE] feat: implement useSuspendedApiCall

### DIFF
--- a/frontend/src/hooks/use-api-call.ts
+++ b/frontend/src/hooks/use-api-call.ts
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useState} from 'react'
 
-import {apiCall, getOrRegisterApiCache, invalidateApiCache} from '@/utils/api'
+import {apiCall, getApiCache, invalidateApiCache} from '@/utils/api'
 
 export interface UseApiResult<T> {
   data?: T
@@ -103,6 +103,6 @@ export function useSuspendedApiCall<T>(
     // invalidate cache every request
     return () => invalidateApiCache(path)
   }, [path])
-  const promise = getOrRegisterApiCache(path, init)
+  const promise = getApiCache(path, init)
   return {data: use(promise)}
 }

--- a/frontend/src/hooks/use-api-call.ts
+++ b/frontend/src/hooks/use-api-call.ts
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useState} from 'react'
 
-import {apiCall} from '@/utils/api'
+import {apiCall, getOrRegisterApiCache, invalidateApiCache} from '@/utils/api'
 
 export interface UseApiResult<T> {
   data?: T
@@ -59,4 +59,50 @@ export function useApiCall<T>(path: string, params: UseApiParam<T> = {}): UseApi
   }, [doFetch])
 
   return {data, loading, error, reload: doFetch}
+}
+
+export interface ExtendedPromise<T> extends PromiseLike<T> {
+  status?: 'pending' | 'fulfilled' | 'rejected'
+  value?: T
+  reason?: unknown
+}
+
+export function use<T>(promise: ExtendedPromise<T>) {
+  if (promise.status === 'fulfilled') {
+    return promise.value
+  } else if (promise.status === 'rejected') {
+    throw promise.reason
+  } else if (promise.status === 'pending') {
+    throw promise
+  } else {
+    promise.status = 'pending'
+    promise.then(
+      (result) => {
+        promise.status = 'fulfilled'
+        promise.value = result
+      },
+      (reason) => {
+        promise.status = 'rejected'
+        promise.reason = reason
+      },
+    )
+    throw promise as ExtendedPromise<T>
+  }
+}
+
+interface UseSuspendedApiCallResult<T> {
+  data: T | undefined
+}
+
+export function useSuspendedApiCall<T>(
+  path: string,
+  init?: RequestInit,
+): UseSuspendedApiCallResult<T> {
+  // TODO: implement proper cache management
+  useEffect(() => {
+    // invalidate cache every request
+    return () => invalidateApiCache(path)
+  }, [path])
+  const promise = getOrRegisterApiCache(path, init)
+  return {data: use(promise)}
 }

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -14,7 +14,7 @@ export async function apiCall(path: string, init?: RequestInit) {
 
 const apiCallCache = new Map<string, ExtendedPromise<unknown>>()
 
-export function getOrRegisterApiCache(path: string, init?: RequestInit) {
+export function getApiCache(path: string, init?: RequestInit) {
   const res = apiCallCache.get(path)
   if (res) return res
   const newRes = createApiCallPromise(path, init)

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -30,6 +30,6 @@ async function createApiCallPromise(path: string, init?: RequestInit) {
   const res = await apiCall(path, {
     ...init,
   })
-  if (res.status < 200 || res.status >= 300) throw new Error(res.status.toString())
+  if (!res.ok) throw new Error(res.status.toString())
   return await res.json()
 }

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,11 +1,35 @@
+import {ExtendedPromise} from '@/hooks/use-api-call'
+
 import {API_BASE_URL} from './constants'
 import {sessionProvider} from './session'
 
-export function apiCall(path: string, init?: RequestInit): Promise<Response> {
+export async function apiCall(path: string, init?: RequestInit) {
   if (!sessionProvider.session) throw new Error('세션이 만료되었습니다')
   // todo: refresh token on 401
   return fetch(`${API_BASE_URL}${path}`, {
     ...init,
     headers: {...init?.headers, Authorization: `Bearer ${sessionProvider.session.accessToken}`},
   })
+}
+
+const apiCallCache = new Map<string, ExtendedPromise<unknown>>()
+
+export function getOrRegisterApiCache(path: string, init?: RequestInit) {
+  const res = apiCallCache.get(path)
+  if (res) return res
+  const newRes = createApiCallPromise(path, init)
+  apiCallCache.set(path, newRes)
+  return newRes
+}
+
+export function invalidateApiCache(path: string) {
+  apiCallCache.delete(path)
+}
+
+async function createApiCallPromise(path: string, init?: RequestInit) {
+  const res = await apiCall(path, {
+    ...init,
+  })
+  if (res.status < 200 || res.status >= 300) throw new Error(res.status.toString())
+  return await res.json()
 }


### PR DESCRIPTION
## 구현 내용

- close #161

## 고민 사항
- suspense를 트리거 하는 방법
- promise의 저장 위치/방식: state등 react component lifecycle내에서 관리하게 되면 예상치 못한 결과가 나온다 -> 전역 변수로 저장하고 관리(apiCallCache)

## 기타
사용 예시
```tsx
// api call이 진행중인 동안에는 fallback 컴포넌트가 렌더링 된다
function App(){
  return <Suspense fallback={<p>loading</p>}><ComponentThatSuspenses/></Suspense>
}

function ComponentThatSuspenses(){
  const {data: someData} = useSuspendedApiCall<ResType>('/path/to/api')
  return <DataRenderer data={someData}/>
}
```
