### PR TITLE
[FE] feat: implement portal component and useModal hook

### DIFF
--- a/frontend/src/components/portal/index.ts
+++ b/frontend/src/components/portal/index.ts
@@ -1,0 +1,1 @@
+export * from './portal'

--- a/frontend/src/components/portal/portal.tsx
+++ b/frontend/src/components/portal/portal.tsx
@@ -1,0 +1,12 @@
+import {PropsWithChildren} from 'react'
+import {createPortal} from 'react-dom'
+
+export interface PortalProps {
+  id: string
+}
+
+export function Portal({children, id}: PropsWithChildren<PortalProps>) {
+  const container = document.getElementById(id) || document.body
+
+  return <>{createPortal(children, container)}</>
+}

--- a/frontend/src/hooks/use-modal.ts
+++ b/frontend/src/hooks/use-modal.ts
@@ -1,0 +1,23 @@
+import {useCallback, useMemo, useState} from 'react'
+
+export interface UseModalReturn {
+  open: boolean
+  onOpen: () => void
+  onClose: () => void
+}
+
+export function useModal(initialOpen = false): UseModalReturn {
+  const [open, setOpen] = useState(initialOpen)
+
+  const onOpen = useCallback(() => setOpen(true), [])
+  const onClose = useCallback(() => setOpen(false), [])
+
+  return useMemo(
+    () => ({
+      open,
+      onOpen,
+      onClose,
+    }),
+    [open, onOpen, onClose],
+  )
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,12 +5,16 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 
 import {App} from './App.tsx'
+import {ChatModalProvider} from './providers'
 import {theme} from './styles/theme.ts'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
-      <App />
+      <ChatModalProvider>
+        <App />
+        <div id="chat-modal" />
+      </ChatModalProvider>
     </ThemeProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/pages/components/chat-modal/chat-modal.tsx
+++ b/frontend/src/pages/components/chat-modal/chat-modal.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled'
+
+import {Portal} from '@/components/portal'
+
+interface ChatModal {
+  open: boolean
+  onClose: () => void
+}
+
+export function ChatModal({open, onClose}: ChatModal) {
+  return (
+    <Portal id="chat-modal">
+      {open && (
+        <ChatModalContainer>
+          Chat modal
+          <button onClick={onClose}>close modal</button>
+        </ChatModalContainer>
+      )}
+    </Portal>
+  )
+}
+
+const ChatModalContainer = styled.div(() => ({}))

--- a/frontend/src/pages/components/chat-modal/index.ts
+++ b/frontend/src/pages/components/chat-modal/index.ts
@@ -1,0 +1,1 @@
+export * from './chat-modal'

--- a/frontend/src/pages/components/index.ts
+++ b/frontend/src/pages/components/index.ts
@@ -1,0 +1,1 @@
+export * from './chat-modal'

--- a/frontend/src/providers/chat-modal-provider.tsx
+++ b/frontend/src/providers/chat-modal-provider.tsx
@@ -1,0 +1,22 @@
+import {createContext, type PropsWithChildren, useContext} from 'react'
+
+import {useModal, type UseModalReturn} from '@/hooks/use-modal'
+
+const ChatModalContext = createContext<UseModalReturn | null>(null)
+
+export function ChatModalProvider({children}: PropsWithChildren) {
+  const modal = useModal()
+
+  return <ChatModalContext.Provider value={modal}>{children}</ChatModalContext.Provider>
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useChatModal() {
+  const modal = useContext(ChatModalContext)
+
+  if (!modal) {
+    throw new Error('useChatModal should be used in ChatModalProvider')
+  }
+
+  return modal
+}

--- a/frontend/src/providers/index.ts
+++ b/frontend/src/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './chat-modal-provider'


### PR DESCRIPTION
## 구현 내용

- close #189 
- `Portal` component
- `useModal` hook
- `ChatProvider,` `ChatModal`(디자인 X) 구현

## 고민 사항

### `ChatModal` 상태 (context API 이용)
- `ChatModal`을 학생 입장에서 `문의` 버튼 혹은 사이드바의 `채팅` 버튼을 클릭할 때 `open` 해야합니다. 그래서 `ChatModal` 의 상태를 `context` 로 관리하고자 합니다.
```tsx
// use case
function Page() {
  const chatModal = useChatModal()

  return (
    <>
      <Button onClick={chatModal.onOpen}>문의</Button>
      <ChatModal open={chatMoal.open} onClose={chatModal.onClose} />
    </>
  )
}
```

<img width="769" alt="스크린샷 2024-02-20 오후 12 10 15" src="https://github.com/softeerbootcamp-3rd/Team1-driving-today/assets/33178048/e76f8142-4cb9-44ec-8094-bbef558da79b">

### Modal 닫기 기능
키보드 `esc` 혹은 모달 외부 클릭 시 모달을 닫게할 수 있는 기능을 추가하면 좋을 것같습니다. (사용성 up)


## 기타
