### PR TITLE
fix: useInfiniteFetch 타입 수정

### DIFF
--- a/frontend/src/hooks/use-infinite-fetch.ts
+++ b/frontend/src/hooks/use-infinite-fetch.ts
@@ -20,7 +20,7 @@ export interface UseInfniteFetchReturn<TData> {
   hasNextPage: boolean
 }
 
-export function useInfiniteFetch<TData = unknown[], TPageParam = unknown>({
+export function useInfiniteFetch<TData extends unknown[] = unknown[], TPageParam = unknown>({
   queryFn,
   initialPageParam,
   getNextPageParam,

--- a/frontend/src/hooks/use-infinite-fetch.ts
+++ b/frontend/src/hooks/use-infinite-fetch.ts
@@ -14,18 +14,18 @@ export interface UseInfiniteFetchArg<TData, TPageParam> {
 
 export interface UseInfniteFetchReturn<TData> {
   fetchNextPage: () => Promise<unknown>
-  data?: TData[]
+  data?: TData
   error?: unknown
   loading: boolean
   hasNextPage: boolean
 }
 
-export function useInfiniteFetch<TData, TPageParam>({
+export function useInfiniteFetch<TData = unknown[], TPageParam = unknown>({
   queryFn,
   initialPageParam,
   getNextPageParam,
 }: UseInfiniteFetchArg<TData, TPageParam>): UseInfniteFetchReturn<TData> {
-  const [data, setData] = useState<TData[]>()
+  const [data, setData] = useState<TData>()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<unknown>()
   const [hasNextPage, setHasNextPage] = useState(true)
@@ -47,6 +47,8 @@ export function useInfiniteFetch<TData, TPageParam>({
       if (!nextPageParamRef.current) {
         setHasNextPage(false)
       }
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
       setData((prev) => (prev ? prev : []).concat(res))
       setError(null)
     } catch (error) {

--- a/frontend/src/pages/search/components/detail-dialog.tsx
+++ b/frontend/src/pages/search/components/detail-dialog.tsx
@@ -92,6 +92,15 @@ interface InstructorDetailResponse {
   averageRating: number
 }
 
+type ReviewResponse = {
+  reviewId: number
+  contents: string
+  rating: number
+  createdAt: string
+  reviewerName: string
+  reviewerImage: string
+}[]
+
 const PAGE_SIZE = 5
 function InstructorDetail({id}: {id: number}) {
   // TODO: error handling
@@ -103,7 +112,7 @@ function InstructorDetail({id}: {id: number}) {
     loading,
     fetchNextPage,
   } = useInfiniteFetch({
-    queryFn: ({pageParam}) => {
+    queryFn: ({pageParam}): Promise<ReviewResponse> => {
       return apiCall(
         `/reviews?instructorId=${id}&pageNumber=${pageParam}&pageSize=${PAGE_SIZE}`,
       ).then((res) => res.json())

--- a/frontend/src/pages/search/page.tsx
+++ b/frontend/src/pages/search/page.tsx
@@ -15,6 +15,19 @@ import {objectToQS} from '@/utils/object-to-qs'
 import {DetailDialog, SearchPreview} from './components'
 import type {LoaderData} from './types'
 
+type InstructorsResponse = {
+  distance: number
+  instructorId: number
+  latitude: number
+  longitude: number
+  cert: boolean
+  instructorImage: string
+  pricePerHour: number
+  instructorName: string
+  academyName: string
+  averageRating: number
+}[]
+
 const PAGE_SIZE = 5
 
 export function SearchPage() {
@@ -28,7 +41,7 @@ export function SearchPage() {
 
   // TODO: error handling
   const {data, loading, fetchNextPage} = useInfiniteFetch({
-    queryFn: ({pageParam}) => {
+    queryFn: ({pageParam}): Promise<InstructorsResponse> => {
       return apiCall(
         `/instructors?latitude=${latitude}&longitude=${longitude}&trainingTime=${trainingTime}&reservationTime=${reservationTime}&reservationDate=${reservationDate}&pageNumber=${pageParam}&pageSize=${PAGE_SIZE}`,
       ).then((res) => res.json())


### PR DESCRIPTION
## 구현 내용

- close #191 
- useInfiniteFetch 의 data 타입 수정

## 고민 사항

### useInfiniteFetch data 타입 수정
```ts

type ReviewResponse = {
...
}[] // Response 가 배열로 넘어옴

const {
  data: reviews, // ReviewResponse
  loading,
  fetchNextPage,
} = useInfiniteFetch({
  queryFn: ({pageParam}): Promise<ReviewResponse> => {
    return apiCall(
      `/reviews?instructorId=${id}&pageNumber=${pageParam}&pageSize=${PAGE_SIZE}`,
    ).then((res) => res.json())
  },
  initialPageParam: 1,
  getNextPageParam: ({pageParam, lastPage}) => {
    const isLastPage = lastPage.length < PAGE_SIZE
    const nextPageParam = pageParam + 1
    return isLastPage ? undefined : nextPageParam
  },
})

return <>{reviews.map(...)}</>
```

## 기타
