### PR TITLE
[FE] feat: useInfiniteFetch error handling + type error fix

### DIFF
--- a/frontend/src/hooks/use-infinite-fetch.ts
+++ b/frontend/src/hooks/use-infinite-fetch.ts
@@ -1,15 +1,20 @@
 import {useCallback, useMemo, useRef, useState} from 'react'
 
 export interface UseInfiniteFetchArg<TData, TPageParam> {
-  queryFn: ({pageParam}: {pageParam: TPageParam}) => Promise<TData>
+  queryFn: ({pageParam}: {pageParam: TPageParam}) => Promise<UseInfiniteFetchResponse<TData>>
   initialPageParam: TPageParam
   getNextPageParam: ({
     pageParam,
     lastPage,
   }: {
     pageParam: TPageParam
-    lastPage: TData
+    lastPage: UseInfiniteFetchResponse<TData>
   }) => TPageParam | undefined
+}
+
+export interface UseInfiniteFetchResponse<TData> {
+  data: TData
+  statusCode: number
 }
 
 export interface UseInfniteFetchReturn<TData> {
@@ -20,12 +25,12 @@ export interface UseInfniteFetchReturn<TData> {
   hasNextPage: boolean
 }
 
-export function useInfiniteFetch<TData extends unknown[] = unknown[], TPageParam = unknown>({
+export function useInfiniteFetch<TData, TPageParam = unknown>({
   queryFn,
   initialPageParam,
   getNextPageParam,
-}: UseInfiniteFetchArg<TData, TPageParam>): UseInfniteFetchReturn<TData> {
-  const [data, setData] = useState<TData>()
+}: UseInfiniteFetchArg<TData[], TPageParam>): UseInfniteFetchReturn<TData[]> {
+  const [data, setData] = useState<TData[]>()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<unknown>()
   const [hasNextPage, setHasNextPage] = useState(true)
@@ -47,9 +52,7 @@ export function useInfiniteFetch<TData extends unknown[] = unknown[], TPageParam
       if (!nextPageParamRef.current) {
         setHasNextPage(false)
       }
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      setData((prev) => (prev ? prev : []).concat(res))
+      setData((prev) => (prev ?? []).concat(res.data))
       setError(null)
     } catch (error) {
       setError(error)

--- a/frontend/src/hooks/use-infinite-fetch.ts
+++ b/frontend/src/hooks/use-infinite-fetch.ts
@@ -1,25 +1,20 @@
 import {useCallback, useMemo, useRef, useState} from 'react'
 
-export interface UseInfiniteFetchArg<TData, TPageParam> {
-  queryFn: ({pageParam}: {pageParam: TPageParam}) => Promise<UseInfiniteFetchResponse<TData>>
+export interface UseInfiniteFetchArg<TDataArray, TPageParam> {
+  queryFn: ({pageParam}: {pageParam: TPageParam}) => Promise<TDataArray>
   initialPageParam: TPageParam
   getNextPageParam: ({
     pageParam,
     lastPage,
   }: {
     pageParam: TPageParam
-    lastPage: UseInfiniteFetchResponse<TData>
+    lastPage: TDataArray
   }) => TPageParam | undefined
 }
 
-export interface UseInfiniteFetchResponse<TData> {
-  data: TData
-  statusCode: number
-}
-
-export interface UseInfniteFetchReturn<TData> {
+export interface UseInfniteFetchReturn<TDataArray> {
   fetchNextPage: () => Promise<unknown>
-  data?: TData
+  data?: TDataArray
   error?: unknown
   loading: boolean
   hasNextPage: boolean
@@ -52,7 +47,7 @@ export function useInfiniteFetch<TData, TPageParam = unknown>({
       if (!nextPageParamRef.current) {
         setHasNextPage(false)
       }
-      setData((prev) => (prev ?? []).concat(res.data))
+      setData((prev) => (prev ?? []).concat(res))
       setError(null)
     } catch (error) {
       setError(error)

--- a/frontend/src/pages/search/page.tsx
+++ b/frontend/src/pages/search/page.tsx
@@ -40,18 +40,17 @@ export function SearchPage() {
   const [hoverInstructorId, setHoverInstructorId] = useState<number | null>(null)
 
   // TODO: error handling
-  const {data, loading, fetchNextPage} = useInfiniteFetch<InstructorsResponseItem, number>({
+  const {data, loading, fetchNextPage} = useInfiniteFetch({
     queryFn: async ({pageParam}) => {
       const res = await apiCall(
         `/instructors?latitude=${latitude}&longitude=${longitude}&trainingTime=${trainingTime}&reservationTime=${reservationTime}&reservationDate=${reservationDate}&pageNumber=${pageParam}&pageSize=${PAGE_SIZE}`,
       )
-      return {data: await res.json(), statusCode: res.status}
+      if (!res.ok) throw new Error('server error')
+      return (await res.json()) as InstructorsResponseItem[]
     },
     initialPageParam: 1,
     getNextPageParam: ({pageParam, lastPage}) => {
-      console.log(lastPage)
-      if (lastPage.statusCode !== 200) return
-      const isLastPage = lastPage.data.length < PAGE_SIZE
+      const isLastPage = lastPage.length < PAGE_SIZE
       const nextPageParam = pageParam + 1
       return isLastPage ? undefined : nextPageParam
     },


### PR DESCRIPTION
## 구현 내용

- close #209 close #229
  - ~~queryFn의 반환값에 statusCode 추가~~
  - #198 에서 응답 형식을 변경하여 getNextPageParam에서 statusCode 에 의존할 필요가 없어짐
- close #191
  - TData를 unknown[] 이 아닌 배열을 구성하는 아이템 타입 자체를 받도록 수정

## 고민 사항
- 적절한 추상화의 정도
  - getNextPageParam에서도 응답을 직접 사용할 수 있도록 queryFn과 getNextPageParam의 로직을 합치면 어떨까?

## 기타
