### PR TITLE
[BE] feat : 학원 검색 api 

### DIFF
--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/academy/AcademyController.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/academy/AcademyController.java
@@ -1,0 +1,24 @@
+package com.drivingtoday.domain.academy;
+
+import com.drivingtoday.domain.academy.dto.AcademySearchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class AcademyController {
+
+    private final AcademyFindService academyFindService;
+
+    @Operation(summary = "[강사] 학원 이름 검색")
+    @GetMapping("/academies")
+    public ResponseEntity<List<AcademySearchResponse>> academySearch(@RequestParam("name") String name) {
+        return ResponseEntity.ok(academyFindService.findAcademies(name));
+    }
+}

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/academy/AcademyFindService.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/academy/AcademyFindService.java
@@ -1,0 +1,19 @@
+package com.drivingtoday.domain.academy;
+
+import com.drivingtoday.domain.academy.dto.AcademySearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AcademyFindService {
+
+    private final AcademyRepository academyRepository;
+
+    public List<AcademySearchResponse> findAcademies(String name) {
+        List<Academy> academies = academyRepository.findAllByName(name);
+        return academies.stream().map(AcademySearchResponse::from).toList();
+    }
+}

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/academy/AcademyRepository.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/academy/AcademyRepository.java
@@ -2,5 +2,8 @@ package com.drivingtoday.domain.academy;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AcademyRepository extends JpaRepository<Academy, Long> {
+    List<Academy> findAllByName(String name);
 }

--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/academy/dto/AcademySearchResponse.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/academy/dto/AcademySearchResponse.java
@@ -1,0 +1,20 @@
+package com.drivingtoday.domain.academy.dto;
+
+import com.drivingtoday.domain.academy.Academy;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AcademySearchResponse {
+
+    private Long academyId;
+    private String name;
+
+    public static AcademySearchResponse from(Academy academy) {
+        return AcademySearchResponse.builder()
+                .academyId(academy.getId())
+                .name(academy.getName())
+                .build();
+    }
+}

--- a/backend/driving-today/src/main/java/com/drivingtoday/global/auth/config/JwtFilter.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/global/auth/config/JwtFilter.java
@@ -8,7 +8,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -27,7 +26,7 @@ public class JwtFilter extends OncePerRequestFilter {
     private static ThreadLocal<Authentication> auth = new ThreadLocal<>();
     private final JwtProvider jwtProvider;
     private final String[] allowUriList
-            = new String[]{"*/health", "*/register", "*/login", "/swagger-ui/*", "**/api-docs**"};
+            = new String[]{"*/health", "*/academies**", "*/register", "*/login", "/swagger-ui/*", "**/api-docs**"};
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {


### PR DESCRIPTION
## 구현 내용

- close #224 
  - 학원 이름을 쿼리 파라미터로 넘겨 검색하면, 
      ```
      [
        {
          "academyId": 1,
          "name": "공릉자동차전문운전학원"
        }
      ]
      ```
      이런 형식으로 응답

## 고민 사항

## 기타
