### PR TITLE
[FE] fix(vite.config.ts): `build.assetInlineLimit` setting to zero

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,4 +8,7 @@ export default defineConfig({
   resolve: {
     alias: [{find: '@', replacement: path.resolve(__dirname, './src')}],
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 })


### PR DESCRIPTION
## 구현 내용

- close #244 

## 고민 사항

### 해결
- [vite 에서 빌드 시 4KB 이내의 asset 은 최적화를 위해 base64 url로 inline 처리를 한다고 합니다.](https://vitejs.dev/config/build-options#build-assetsinlinelimit) 지금 사용하고 있는 asset의 크기가 모두 4kb보다 작아 base64 url로 변환되었고, mask: 'url(svg asset url)' 에서 정상적으로 처리하지 못하고 있었습니다.

### 우려되는 점

- `asset`을 모두 빌드하기 때문에 `http` 요청량이 증가할 것으로 예상됩니다. 따라사 svg sprite 과 같은 `asset` 최적화 기법을 적용해보면 좋을 거같습니다

## 기타

- [vite build.assetsInlineLimit](https://vitejs.dev/config/build-options#build-assetsinlinelimit)