### PR TITLE
[BE] feat : 이름으로 학원 찾는 쿼리 include 방식으로 변경

### DIFF
--- a/backend/driving-today/src/main/java/com/drivingtoday/domain/academy/AcademyRepository.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/domain/academy/AcademyRepository.java
@@ -1,9 +1,11 @@
 package com.drivingtoday.domain.academy;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface AcademyRepository extends JpaRepository<Academy, Long> {
+    @Query("Select a from Academy a WHERE a.name like %:name%")
     List<Academy> findAllByName(String name);
 }


### PR DESCRIPTION
## 구현 내용

- close #255 
    - OO를 입력하면 OO을 포함한 모든 학원 리스트 반환
    ### AS IS
    ```
    List<Academy> findAllByName(String name);
    ```
    ### TO BE
    ```
    @Query("Select a from Academy a WHERE a.name like %:name%")
    List<Academy> findAllByName(String name);
    ```

## 고민 사항

## 기타
