### PR TITLE
[FE] feat: add gc to api cache

### DIFF
--- a/frontend/src/hooks/use-api-call.ts
+++ b/frontend/src/hooks/use-api-call.ts
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useState} from 'react'
 
-import {apiCall, getApiCache, invalidateApiCache} from '@/utils/api'
+import {apiCall, getApiCache, queueApiCacheInvalidation} from '@/utils/api'
 
 export interface UseApiResult<T> {
   data?: T
@@ -91,7 +91,7 @@ export function use<T>(promise: ExtendedPromise<T>) {
 }
 
 interface UseSuspendedApiCallResult<T> {
-  data: T | undefined
+  data: T | unknown
 }
 
 export function useSuspendedApiCall<T>(
@@ -101,8 +101,8 @@ export function useSuspendedApiCall<T>(
   // TODO: implement proper cache management
   useEffect(() => {
     // invalidate cache every request
-    return () => invalidateApiCache(path)
+    return () => queueApiCacheInvalidation(path)
   }, [path])
   const promise = getApiCache(path, init)
-  return {data: use(promise)}
+  return {data: use<unknown>(promise)}
 }


### PR DESCRIPTION

## 구현 내용

- close #181
- 기존에는 useSuspendedApiCall 사용하는 컴포넌트 언마운트시 메모리에서 promise 삭제, 이제 어느정도 딜레이(CACHE_PRESERVE_TIME)를 줘서 컴포넌트가 언마운트 된 후에 일정시간 유지되다가 삭제됨

## 고민 사항

## 기타
