### PR TITLE
[BE] feat : 토큰 재발급 로직 추가

### DIFF
--- a/backend/driving-today/build.gradle
+++ b/backend/driving-today/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	// https://mvnrepository.com/artifact/com.google.code.gson/gson
+	implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
+
 
 	implementation 'org.redisson:redisson-spring-boot-starter:3.18.0'
 }

--- a/backend/driving-today/src/main/java/com/drivingtoday/global/auth/jwt/JwtProvider.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/global/auth/jwt/JwtProvider.java
@@ -50,7 +50,7 @@ public class JwtProvider {
 
     public Jwt createJwt(Map<String, Object> claims) {
         String accessToken = createAT(claims, getExpireDateAccessToken());
-        String refreshToken = createRT(new HashMap<>(), getExpireDateRefreshToken());
+        String refreshToken = createRT(claims, getExpireDateRefreshToken());
         return Jwt.of(accessToken, refreshToken);
     }
 
@@ -59,6 +59,11 @@ public class JwtProvider {
                 .setSigningKey(key)
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    public String getType(String token){
+        Claims claims = getClaims(token);
+        return (String) claims.get("type");
     }
 
     public Date getExpireDateAccessToken() {

--- a/backend/driving-today/src/main/java/com/drivingtoday/global/auth/jwt/JwtProvider.java
+++ b/backend/driving-today/src/main/java/com/drivingtoday/global/auth/jwt/JwtProvider.java
@@ -31,7 +31,16 @@ public class JwtProvider {
         this.key = secretKey;
     }
 
-    public String createToken(Map<String, Object> claims, Date expireDate) {
+    public String createAT(Map<String, Object> claims, Date expireDate) {
+        claims.put("type", "AT");
+        return Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(expireDate)
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+    public String createRT(Map<String, Object> claims, Date expireDate) {
+        claims.put("type", "RT");
         return Jwts.builder()
                 .setClaims(claims)
                 .setExpiration(expireDate)
@@ -40,8 +49,8 @@ public class JwtProvider {
     }
 
     public Jwt createJwt(Map<String, Object> claims) {
-        String accessToken = createToken(claims, getExpireDateAccessToken());
-        String refreshToken = createToken(new HashMap<>(), getExpireDateRefreshToken());
+        String accessToken = createAT(claims, getExpireDateAccessToken());
+        String refreshToken = createRT(new HashMap<>(), getExpireDateRefreshToken());
         return Jwt.of(accessToken, refreshToken);
     }
 

--- a/backend/driving-today/src/test/java/com/drivingtoday/global/auth/jwt/JwtProviderTest.java
+++ b/backend/driving-today/src/test/java/com/drivingtoday/global/auth/jwt/JwtProviderTest.java
@@ -45,4 +45,17 @@ class JwtProviderTest {
         Assertions.assertThat(jwtProvider.getClaims(refreshToken).get("type")).isEqualTo("RT");
     }
 
+    @Test
+    @DisplayName("토큰 타입 가져오는 메서드 테스트")
+    void 타입가져오기(){
+        //given
+        Map<String, Object> claims = new HashMap<>();
+        claims.put(JwtProvider.CLAIM_USERID, 1L);
+        claims.put(JwtProvider.CLAIM_ROLE, Role.STUDENT);
+        String accessToken = jwtProvider.createAT(claims, jwtProvider.getExpireDateAccessToken());
+        //when
+        String type = jwtProvider.getType(accessToken);
+        //then
+        Assertions.assertThat(type).isEqualTo("AT");
+    }
 }

--- a/backend/driving-today/src/test/java/com/drivingtoday/global/auth/jwt/JwtProviderTest.java
+++ b/backend/driving-today/src/test/java/com/drivingtoday/global/auth/jwt/JwtProviderTest.java
@@ -1,0 +1,48 @@
+package com.drivingtoday.global.auth.jwt;
+
+import com.drivingtoday.global.auth.constants.Role;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@SpringBootTest
+class JwtProviderTest {
+    @Value("${jwt.credentials.secret-key}")
+    String secretKey;
+
+    @Autowired
+    JwtProvider jwtProvider = new JwtProvider(secretKey);
+
+    @Test
+    @DisplayName("access token 만들기")
+    void MakingAT(){
+        //given
+        Map<String, Object> claims = new HashMap<>();
+        claims.put(JwtProvider.CLAIM_USERID, 1L);
+        claims.put(JwtProvider.CLAIM_ROLE, Role.STUDENT);
+        //when
+        String accessToken = jwtProvider.createAT(claims, jwtProvider.getExpireDateAccessToken());
+        //then
+        Assertions.assertThat(jwtProvider.getClaims(accessToken).get("type")).isEqualTo("AT");
+        Assertions.assertThat(jwtProvider.getClaims(accessToken).get("userId")).isEqualTo(1);
+        Assertions.assertThat(jwtProvider.getClaims(accessToken).get("role")).isEqualTo("STUDENT");
+    }
+
+    @Test
+    @DisplayName("refresh token 만들기")
+    void MakingRT(){
+        //given
+        Map<String, Object> claims = new HashMap<>();
+        //when
+        String refreshToken = jwtProvider.createRT(claims, jwtProvider.getExpireDateAccessToken());
+        //then
+        Assertions.assertThat(jwtProvider.getClaims(refreshToken).get("type")).isEqualTo("RT");
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

- close #294 
    - access token 만료시 refresh token으로 두 토큰 모두 재발급하는 로직 추가
## 고민 사항

## 기타
